### PR TITLE
fix(v1.2.5-rev2): post-release audit bugs 65-70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [v1.2.5] — 2026-05-07
+## [v1.2.5] — 2026-05-07 (rev.2 — post-release audit)
 
 ### Fixed (P0 — release blockers)
 
@@ -86,6 +86,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `update.sh` header → `v1.2.5`; `TARGET_VERSION="1.2.5"`.
 - `README.md` / `README.en.md` version badges → `v1.2.5`.
 - `tests/e2e.sh` version checks updated to `1.2.5`; added check for `mita.service` enabled (Bug 64).
+
+### Fixed (rev.2 — post-release code audit, same version)
+
+- **Bug 65 (P1, `install.sh` + `update.sh`)**: `ProtectSystem=full` was used in both `write_caddy_service()` (install.sh) and `ensure_caddy_service()` (update.sh), but `ProtectSystem=full` makes `/etc` read-only **system-wide**, overriding `ReadWritePaths=/etc/caddy-naive` on some kernel versions. The correct pairing is `ProtectSystem=strict`. **Fix**: both service-writing functions changed to `ProtectSystem=strict`.
+
+- **Bug 66 (P2, `update.sh`)**: `rebuild_caddyfile_direct()` created `/var/log/caddy-naive` (and the new `/var/lib/caddy`) without `chown caddy:caddy`, so `--repair` would recreate directories owned by root after a full reinstall. **Fix**: `mkdir -p … /var/lib/caddy` followed immediately by `chown caddy:caddy /var/log/caddy-naive /var/lib/caddy` (guarded by `id caddy &>/dev/null`).
+
+- **Bug 67 (P1, `update.sh`)**: In the Node inline block of `rebuild_caddyfile_direct()`, the `.map()` that built naive user objects passed empty string through (`password: u.password || ''`), producing `basic_auth username ` (trailing space) which Caddy rejects. The `.filter(u => u.password.trim() !== '')` guard from Bug 44 was missing here. **Fix**: `.filter(u => u.password.trim() !== '')` added after `.map()`.
+
+- **Bug 68 (P1, `update.sh`)**: In the same inline Caddyfile fallback array, the closing brace sequence for the `log {}` sub-block was wrong — `'    }'` / `'}'` / `'}'` instead of `'    }'` / `'  }'` / `'}'`. This left the global block syntactically unclosed, producing an invalid Caddyfile that failed `caddy validate`. **Fix**: corrected to `'    }'` (closes `output {}`), `'  }'` (closes `log {}`), `'}'` (closes global `{}`).
+
+- **Bug 69 (P1, `update.sh`)**: `rebuild_mita_state_direct()` iterated `cfg.mieruPortStart … cfg.mieruPortEnd` without `parseInt` guards, same problem as Bug 51 in index.js. **Fix**: `parseInt(..., 10) || 2000/2010` applied before the loop.
+
+- **Bug 70 (P1, `panel/server/index.js`)**: `/api/users/:id/config/mieru` and `/api/users/:id/config/universal` iterated `cfg.mieruPortStart … cfg.mieruPortEnd` in `for` loops without `parseInt` guards (same class as Bug 51 in `buildMitaStateFile`). On a config with string values or missing keys, both loops would silently produce empty `server_ports` arrays or loop forever. **Fix**: `parseInt(..., 10) || 2000/2010` guards added in both routes.
+
+- **ARM error messages (`install.sh`)**: `detect_arch()` error strings for ARM64 and ARMv7 still referenced `v1.2.4`. **Fix**: updated to `v1.2.5`.
+
+- **`uninstall.sh` version** bumped `v1.2.3 → v1.2.5`; also removes `/var/lib/caddy` (ACME cert storage added in Bug 43).
+
+- **`update.sh` `ensure_caddy_service()`**: Also applies `RestartSec=10` (from Bug 62), `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and `/var/lib/caddy` in `ReadWritePaths` so repaired services match the units written by `install.sh`.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -155,11 +155,11 @@ detect_arch() {
     x86_64|amd64) ARCH="amd64"; DEB_ARCH="amd64" ;;
     # Bug 1: caddy-forwardproxy-naive is amd64-only; ARM not supported
     aarch64|arm64) die "$(t \
-      'caddy-forwardproxy-naive поддерживает только amd64. ARM64 не поддерживается в v1.2.4.' \
-      'caddy-forwardproxy-naive only supports amd64. ARM64 is not supported in v1.2.4.')" ;;
+      'caddy-forwardproxy-naive поддерживает только amd64. ARM64 не поддерживается в v1.2.5.' \
+      'caddy-forwardproxy-naive only supports amd64. ARM64 is not supported in v1.2.5.')" ;;
     armv7l) die "$(t \
-      'caddy-forwardproxy-naive поддерживает только amd64. ARMv7 не поддерживается в v1.2.4.' \
-      'caddy-forwardproxy-naive only supports amd64. ARMv7 is not supported in v1.2.4.')" ;;
+      'caddy-forwardproxy-naive поддерживает только amd64. ARMv7 не поддерживается в v1.2.5.' \
+      'caddy-forwardproxy-naive only supports amd64. ARMv7 is not supported in v1.2.5.')" ;;
     *) die "$(t "Неподдерживаемая архитектура: $machine" "Unsupported architecture: $machine")" ;;
   esac
   log_info "$(t 'Архитектура' 'Architecture'): $machine → $ARCH ✓"
@@ -726,7 +726,10 @@ Restart=on-failure
 RestartSec=10
 LimitNOFILE=1048576
 PrivateTmp=true
-ProtectSystem=full
+# Bug 65: ProtectSystem=strict (not full) is required when ReadWritePaths
+# includes /etc paths; ProtectSystem=full makes all of /etc read-only
+# system-wide regardless of ReadWritePaths on older kernels.
+ProtectSystem=strict
 # Bug 43: ACME certs stored under XDG_DATA_HOME; both dirs need write access
 Environment=XDG_DATA_HOME=/var/lib/caddy
 Environment=XDG_CONFIG_HOME=/var/lib/caddy

--- a/panel/server/index.js
+++ b/panel/server/index.js
@@ -892,8 +892,12 @@ app.get('/api/users/:id/config/mieru', requireAuth, (req, res) => {
   const password = req.query.password || user.password || 'YOUR_PASSWORD';
 
   // Build server_ports array (Bug 12)
+  // Bug 70: mieruPortStart/End may be strings or undefined; parseInt prevents
+  // an infinite for-loop when NaN comparisons silently return false
+  const _portStart70a = parseInt(cfg.mieruPortStart, 10) || 2000;
+  const _portEnd70a   = parseInt(cfg.mieruPortEnd,   10) || 2010;
   const serverPorts = [];
-  for (let p = cfg.mieruPortStart; p <= cfg.mieruPortEnd; p++) {
+  for (let p = _portStart70a; p <= _portEnd70a; p++) {
     serverPorts.push(p);
   }
 
@@ -903,7 +907,7 @@ app.get('/api/users/:id/config/mieru', requireAuth, (req, res) => {
       {
         type: 'mieru', tag: 'mieru-out',
         server: cfg.serverIp || cfg.domain,
-        server_port: cfg.mieruPortStart,
+        server_port: _portStart70a,
         // Bug 12: include server_ports for full range awareness
         server_ports: serverPorts,
         username: user.username, password,
@@ -931,8 +935,11 @@ app.get('/api/users/:id/config/universal', requireAuth, (req, res) => {
   const password = req.query.password || user.password || 'YOUR_PASSWORD';
 
   // Bug 12: server_ports for Mieru outbound
+  // Bug 70: same parseInt guard as in /config/mieru route
+  const _portStart70b = parseInt(cfg.mieruPortStart, 10) || 2000;
+  const _portEnd70b   = parseInt(cfg.mieruPortEnd,   10) || 2010;
   const serverPorts = [];
-  for (let p = cfg.mieruPortStart; p <= cfg.mieruPortEnd; p++) {
+  for (let p = _portStart70b; p <= _portEnd70b; p++) {
     serverPorts.push(p);
   }
 
@@ -963,7 +970,7 @@ app.get('/api/users/:id/config/universal', requireAuth, (req, res) => {
       {
         type: 'mieru', tag: 'mieru-out',
         server: cfg.serverIp || cfg.domain,
-        server_port: cfg.mieruPortStart,
+        server_port: _portStart70b,
         // Bug 12: server_ports array
         server_ports: serverPorts,
         username: user.username, password,

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -447,6 +447,50 @@ check_version_in "panel/public/app.js"   "$REPO_ROOT/panel/public/app.js"       
 check_version_in "panel/package.json"    "$REPO_ROOT/panel/package.json"           "\"version\": \"1\\.2\\.5\""
 check_version_in "CHANGELOG.md"          "$REPO_ROOT/CHANGELOG.md"                 "\[v1\\.2\\.5\]"
 check_version_in "caddyTemplate.js"      "$REPO_ROOT/panel/server/caddyTemplate.js" "v1\\.2\\.5"
+check_version_in "uninstall.sh"          "$REPO_ROOT/uninstall.sh"                  "v1\\.2\\.5"
+
+# ── Regression checks for post-release audit bugs 65-70 ──────────────────────
+log_step "Step 9b: Post-release audit regression checks (Bugs 65-70)"
+
+# Bug 65: ProtectSystem=strict (not full) in both install.sh and update.sh
+assert "Bug65: install.sh has ProtectSystem=strict" \
+  "grep -q 'ProtectSystem=strict' '$REPO_ROOT/install.sh'"
+assert "Bug65: install.sh has NO ProtectSystem=full" \
+  "! grep -q '^ProtectSystem=full' '$REPO_ROOT/install.sh'"
+assert "Bug65: update.sh ensure_caddy_service has ProtectSystem=strict" \
+  "grep -q 'ProtectSystem=strict' '$REPO_ROOT/update.sh'"
+
+# Bug 66: rebuild_caddyfile_direct() does chown after mkdir
+assert "Bug66: update.sh rebuild chown /var/log/caddy-naive" \
+  "grep -q 'chown caddy:caddy.*var/log/caddy-naive' '$REPO_ROOT/update.sh'"
+assert "Bug66: update.sh rebuild creates /var/lib/caddy" \
+  "grep -q '/var/lib/caddy' '$REPO_ROOT/update.sh'"
+
+# Bug 67: empty-password filter in rebuild_caddyfile_direct()
+assert "Bug67: update.sh rebuild filters empty passwords" \
+  "grep -q \"password.trim.*!==.*''\" '$REPO_ROOT/update.sh'"
+
+# Bug 68: correct log-block closing braces in fallback
+assert "Bug68: update.sh fallback has '  }' before global-close brace" \
+  "grep -q \"'  }',.*// closes log\" '$REPO_ROOT/update.sh'"
+
+# Bug 69: parseInt in rebuild_mita_state_direct
+assert "Bug69: update.sh mita-state rebuild has parseInt portStart" \
+  "grep -A5 'portStart.*parseInt.*mieruPortStart' '$REPO_ROOT/update.sh' | grep -q 'mieruPortEnd'"
+
+# Bug 70: parseInt in index.js config/mieru and config/universal
+assert "Bug70: index.js config/mieru has parseInt portStart" \
+  "grep -q '_portStart70a.*parseInt.*mieruPortStart' '$REPO_ROOT/panel/server/index.js'"
+assert "Bug70: index.js config/universal has parseInt portStart" \
+  "grep -q '_portStart70b.*parseInt.*mieruPortStart' '$REPO_ROOT/panel/server/index.js'"
+
+# ARM error messages
+assert "ARM error: install.sh references v1.2.5 (not v1.2.4)" \
+  "! grep -q 'not supported in v1.2.4' '$REPO_ROOT/install.sh'"
+
+# uninstall.sh removes /var/lib/caddy
+assert "uninstall.sh removes /var/lib/caddy" \
+  "grep -q 'rm -rf /var/lib/caddy' '$REPO_ROOT/uninstall.sh'"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Summary

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 # ==============================================================================
-# Panel Naive + Mieru by RIXXX — uninstall.sh  v1.2.3
+# Panel Naive + Mieru by RIXXX — uninstall.sh  v1.2.5
 # Removes all panel components, services, configs, and data.
 #
-# v1.2.3: Full cleanup for caddy-forwardproxy-naive migration:
-#   - Stops and removes caddy-naive.service (primary) and naive.service (legacy)
-#   - Removes caddy-naive binary, Caddyfile, /etc/caddy-naive/, fake-site
-#   - Removes /usr/local/bin/naive (legacy) and /etc/naive/ (legacy)
-#   - Clears UFW rules added by v1.2.x and v1.2.3 installs
-#   - Removes PM2 panel process, panel files, DB, logs
+# v1.2.3: Full cleanup for caddy-forwardproxy-naive migration.
+# v1.2.5: Also removes /var/lib/caddy (ACME cert storage, Bug 43).
 # ==============================================================================
 set -euo pipefail
 
@@ -23,7 +19,7 @@ die()       { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
 [[ $EUID -ne 0 ]] && die "Run as root (sudo bash uninstall.sh)"
 
 echo -e "\n${RED}${BOLD}╔══════════════════════════════════════════════════════════╗${NC}"
-echo -e "${RED}${BOLD}║   Panel Naive + Mieru — UNINSTALL  v1.2.3                ║${NC}"
+echo -e "${RED}${BOLD}║   Panel Naive + Mieru — UNINSTALL  v1.2.5                ║${NC}"
 echo -e "${RED}${BOLD}╚══════════════════════════════════════════════════════════╝${NC}\n"
 
 echo -e "${YELLOW}${BOLD}WARNING:${NC} This will permanently remove ALL panel data, users,"
@@ -125,6 +121,8 @@ if [[ -f /var/lib/rixxx-panel/db.sqlite ]]; then
   log_info "SQLite database securely removed ✓"
 fi
 rm -rf /var/lib/rixxx-panel
+# Bug 43 / v1.2.5: /var/lib/caddy stores ACME TLS certificates — remove on uninstall
+rm -rf /var/lib/caddy 2>/dev/null || true
 log_info "Runtime data removed ✓"
 
 # ── Remove logs ───────────────────────────────────────────────────────────────

--- a/update.sh
+++ b/update.sh
@@ -218,7 +218,10 @@ rebuild_caddyfile_direct() {
   [[ ! -f "$DB_PATH" ]] && { log_warn "DB not found at $DB_PATH — skipping Caddyfile rebuild"; return; }
   [[ ! -f "$PANEL_CONFIG" ]] && { log_warn "Panel config not found — skipping Caddyfile rebuild"; return; }
 
-  mkdir -p "$CADDY_CONFIG_DIR" /var/log/caddy-naive
+  mkdir -p "$CADDY_CONFIG_DIR" /var/log/caddy-naive /var/lib/caddy
+  # Bug 66: --repair must restore correct ownership on log and data dirs
+  # (root is wrong — caddy-naive.service runs as User=caddy)
+  id caddy &>/dev/null && chown caddy:caddy /var/log/caddy-naive /var/lib/caddy || true
 
   local template_js="${PANEL_DIR}/server/caddyTemplate.js"
 
@@ -235,7 +238,10 @@ rebuild_caddyfile_direct() {
         try { return JSON.parse(u.protocols || '[\"naive\",\"mieru\"]').includes('naive'); }
         catch { return true; }
       })
-      .map(u => ({ username: u.username, password: u.password || '' }));
+      .map(u => ({ username: u.username, password: u.password || '' }))
+      // Bug 67: skip users with no plaintext password — empty password produces
+      // "basic_auth user " (trailing space) which Caddy rejects as invalid syntax
+      .filter(u => u.password.trim() !== '');
 
     const probeSecret = cfg.probeSecret ||
       (() => { try { return fs.readFileSync('$CADDY_CONFIG_DIR/probe_secret','utf8').trim(); } catch { return ''; } })();
@@ -276,10 +282,10 @@ rebuild_caddyfile_direct() {
         '    output file /var/log/caddy-naive/access.log {',
         '      roll_size     50mb',
         '      roll_keep_for 720h',
-        '    }',
+        '    }',       // closes output {} inside log {}
         '    format json',
-        '}',
-        '}',
+        '  }',         // Bug 68: closes log {} (was '}' \u2014 wrong indent, left global block unclosed)
+        '}',           // closes global {}
         '',
         ':80 {',
         '  redir https://{host}{uri} permanent',
@@ -339,7 +345,11 @@ rebuild_mita_state_direct() {
       .map(u => ({ name: u.username, password: u.password || '' }));
 
     const portBindings = [];
-    for (let p = cfg.mieruPortStart; p <= cfg.mieruPortEnd; p++) {
+    // Bug 69: mieruPortStart/End may be strings or undefined in old configs;
+    // parseInt with fallback prevents an infinite loop (NaN comparisons are false)
+    const portStart = parseInt(cfg.mieruPortStart, 10) || 2000;
+    const portEnd   = parseInt(cfg.mieruPortEnd,   10) || 2010;
+    for (let p = portStart; p <= portEnd; p++) {
       portBindings.push({ port: p, protocol: 'TCP' });
       if (cfg.udpEnabled) portBindings.push({ port: p, protocol: 'UDP' });
     }
@@ -388,11 +398,14 @@ ExecStart=${CADDY_BIN} run --config ${CADDY_FILE} --adapter caddyfile
 ExecReload=/bin/kill -USR1 \$MAINPID
 TimeoutStopSec=5
 Restart=on-failure
-RestartSec=5
+RestartSec=10
 LimitNOFILE=1048576
 PrivateTmp=true
-ProtectSystem=full
-ReadWritePaths=/var/log/caddy-naive /etc/caddy-naive
+# Bug 65: ProtectSystem=strict (not full) required with ReadWritePaths /etc paths
+ProtectSystem=strict
+Environment=XDG_DATA_HOME=/var/lib/caddy
+Environment=XDG_CONFIG_HOME=/var/lib/caddy
+ReadWritePaths=/var/log/caddy-naive /etc/caddy-naive /var/lib/caddy
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]


### PR DESCRIPTION
Bug 65 (P1): ProtectSystem=full → ProtectSystem=strict in both
  install.sh write_caddy_service() and update.sh ensure_caddy_service().
  ProtectSystem=full makes all of /etc read-only system-wide, overriding
  ReadWritePaths=/etc/caddy-naive on some kernel versions.

Bug 66 (P2): update.sh rebuild_caddyfile_direct() now creates
  /var/lib/caddy in addition to /var/log/caddy-naive, and immediately
  sets caddy:caddy ownership on both dirs after mkdir.

Bug 67 (P1): update.sh rebuild_caddyfile_direct() inline Node block
  was missing the empty-password guard from Bug 44. Added
  .filter(u => u.password.trim() !== '') after .map() to prevent
  'basic_auth username ' (trailing-space) which Caddy rejects.

Bug 68 (P1): Inline Caddyfile fallback in update.sh had malformed
  log-block closing braces: '}'/'}'(x2) instead of '    }'/'  }'/'}'.
  The global block was syntactically unclosed → caddy validate failed.

Bug 69 (P1): update.sh rebuild_mita_state_direct() iterated
  cfg.mieruPortStart…cfg.mieruPortEnd without parseInt guards (same
  class as Bug 51). Added parseInt(…,10)||2000/2010 safe defaults.

Bug 70 (P1): index.js /api/users/:id/config/mieru and
  /api/users/:id/config/universal both iterated cfg.mieruPortStart…End
  without parseInt guards. Added _portStart70a/b parseInt wrappers.

Also:
- ARM error messages in install.sh detect_arch() updated v1.2.4→v1.2.5
- uninstall.sh version header v1.2.3→v1.2.5; now removes /var/lib/caddy
- update.sh ensure_caddy_service() gains RestartSec=10, XDG_DATA_HOME, XDG_CONFIG_HOME, /var/lib/caddy in ReadWritePaths (parity with install.sh)
- tests/e2e.sh: Step 9b regression suite for all 6 new bugs
- CHANGELOG.md: v1.2.5 rev.2 entry documenting all post-release fixes