### PR TITLE
fix(P0, Bug73): install aborted at write_config_json — bcrypt argv[2] undefined (panel never on :3000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Audit & cascade hardening (`genspark_ai_developer_audit`)
 
+- **Bug 73 (P0, `install.sh`)** — **install aborted at `write_config_json`** on a
+  clean Ubuntu 24.04: the admin password was passed to `node -e` as
+  `process.argv[2]`, but `node -e` has no script-path arg so the value lands at
+  `argv[1]`. `argv[2]` was `undefined` → `bcrypt.hashSync` threw → the
+  `htpasswd` fallback failed too (apache2-utils not installed) → `die`, so
+  `config.json` was never written and the panel/PM2 never started (`:3000` dead).
+  **Fix**: pass the password via the `RIXXX_ADMIN_PASS` env var and read it from
+  `process.env` (also avoids shell-quoting issues with special chars); the
+  fallback now installs `apache2-utils` first. Added `install_panel` fallback to
+  `$PWD/panel` and wrapped `npm install` in a subshell so the main shell's cwd is
+  preserved. Regression checks added to `tests/e2e.sh`.
+
+
 Pre-test tech-lead audit. The Mieru cascade was re-architected from native `egress`
 (Variant A) to the field-tested **Variant B** (redsocks + iptables + mieru-client),
 because the Exit node is a full Mieru server (`mita`), not a raw SOCKS5 endpoint.

--- a/install.sh
+++ b/install.sh
@@ -846,20 +846,29 @@ setup_ufw() {
 install_panel() {
   log_step "$(t 'Установка веб-панели' 'Installing web panel')"
   mkdir -p "$PANEL_DIR"
-  local script_dir; script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [[ -d "$script_dir/panel" ]]; then
-    cp -r "$script_dir/panel/"* "$PANEL_DIR/"
-    log_info "$(t "Файлы панели скопированы из $script_dir/panel ✓" "Panel files copied from $script_dir/panel ✓")"
+  # Locate the local panel/ source robustly: try the script's own directory,
+  # then the current working directory (covers `sudo bash install.sh` from the
+  # cloned repo even when BASH_SOURCE is relative).
+  local script_dir; script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  local src=""
+  if [[ -n "$script_dir" && -d "$script_dir/panel" ]]; then
+    src="$script_dir/panel"
+  elif [[ -d "$PWD/panel" ]]; then
+    src="$PWD/panel"
+  fi
+
+  if [[ -n "$src" ]]; then
+    cp -r "$src/"* "$PANEL_DIR/"
+    log_info "$(t "Файлы панели скопированы из $src ✓" "Panel files copied from $src ✓")"
   else
-    log_warn "$(t 'Исходники не найдены — клонирование из репозитория...' \
-               'Panel source not found — cloning from repo...')"
+    log_warn "$(t 'Локальные исходники не найдены — клонирование из репозитория...' \
+               'Local panel source not found — cloning from repo...')"
     git clone --depth 1 "$REPO_URL" /tmp/panel-src 2>/dev/null || \
       die "$(t 'Не удалось клонировать репозиторий' 'Failed to clone panel source')"
     cp -r /tmp/panel-src/panel/* "$PANEL_DIR/"
     rm -rf /tmp/panel-src
   fi
-  cd "$PANEL_DIR"
-  npm install --production --silent
+  ( cd "$PANEL_DIR" && npm install --production --silent )
   log_info "$(t 'npm зависимости установлены ✓' 'npm dependencies installed ✓')"
 }
 
@@ -870,15 +879,26 @@ write_config_json() {
   local server_ip
   server_ip=$(curl -4 -fsSL https://api.ipify.org 2>/dev/null || hostname -I | awk '{print $1}')
 
-  # Generate bcrypt hash via Node (rounds=12)
+  # Generate bcrypt hash via Node (rounds=12).
+  # Bug 73 (P0): the password is passed via the RIXXX_ADMIN_PASS env var, NOT
+  # argv. With `node -e`, there is no script-path argument, so the first user
+  # arg lands at process.argv[1] (not argv[2]); the old code read argv[2] →
+  # undefined → bcrypt.hashSync threw → install aborted at write_config_json.
+  # Env-var passing also avoids any shell-quoting issues with special chars.
   local bcrypt_hash
-  # Bug fix: run from PANEL_DIR so require('bcryptjs') resolves; use argv[2] (-- shifts index)
-  bcrypt_hash=$(cd "$PANEL_DIR" && node -e "
+  bcrypt_hash=$(cd "$PANEL_DIR" && RIXXX_ADMIN_PASS="$ADMIN_PASS" node -e "
     const bcrypt = require('bcryptjs');
-    process.stdout.write(bcrypt.hashSync(process.argv[2], 12));
-  " -- "$ADMIN_PASS" 2>/dev/null) || {
-    bcrypt_hash=$(htpasswd -bnBC 12 "" "$ADMIN_PASS" 2>/dev/null | tr -d ':\n' | sed 's/^[^\$]*//')
-  }
+    const pw = process.env.RIXXX_ADMIN_PASS || '';
+    if (!pw) { process.exit(2); }
+    process.stdout.write(bcrypt.hashSync(pw, 12));
+  " 2>/dev/null) || true
+  # Fallback: htpasswd (apache2-utils) if Node hashing failed for any reason.
+  if [[ -z "$bcrypt_hash" ]]; then
+    if ! command -v htpasswd &>/dev/null; then
+      DEBIAN_FRONTEND=noninteractive apt-get install -y -qq apache2-utils 2>/dev/null || true
+    fi
+    bcrypt_hash=$(htpasswd -bnBC 12 "" "$ADMIN_PASS" 2>/dev/null | tr -d ':\n' | sed 's/^[^$]*//')
+  fi
   [[ -z "$bcrypt_hash" ]] && die "$(t 'Не удалось создать bcrypt-хеш пароля' 'Failed to generate bcrypt password hash')"
 
   python3 - <<PYCFG

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -492,6 +492,17 @@ assert "ARM error: install.sh references v1.2.6 (not older)" \
 assert "uninstall.sh removes /var/lib/caddy" \
   "grep -q 'rm -rf /var/lib/caddy' '$REPO_ROOT/uninstall.sh'"
 
+# Bug 73 (P0): write_config_json must pass the admin password via env var and
+# read it from process.env (NOT process.argv[2], which is undefined for node -e).
+assert "Bug73: install.sh bcrypt uses RIXXX_ADMIN_PASS env (not argv[2])" \
+  "grep -q 'RIXXX_ADMIN_PASS' '$REPO_ROOT/install.sh' && ! grep -q 'hashSync(process.argv\\[2\\]' '$REPO_ROOT/install.sh'"
+assert "Bug73: install.sh reads pw from process.env.RIXXX_ADMIN_PASS" \
+  "grep -q 'process.env.RIXXX_ADMIN_PASS' '$REPO_ROOT/install.sh'"
+assert "Bug73: install.sh htpasswd fallback installs apache2-utils" \
+  "grep -q 'apache2-utils' '$REPO_ROOT/install.sh'"
+assert "install.sh install_panel falls back to PWD/panel" \
+  "grep -q 'PWD/panel' '$REPO_ROOT/install.sh'"
+
 # ── Cascade Variant B (static) checks ─────────────────────────────────────────
 log_step "Step 9c: Cascade Variant B (redsocks + iptables + mieru-client)"
 


### PR DESCRIPTION
## P0 hotfix — install aborted at `write_config_json` (panel never reached :3000)

Fixes the exact failure RIXXX hit on a clean **Ubuntu 24.04** install: the run
stopped right after `▶ Запись /etc/rixxx-panel/config.json` and the panel never
came up on `127.0.0.1:3000`.

### Root cause (Bug 73)
`write_config_json()` generated the admin bcrypt hash with:
```sh
node -e "... bcrypt.hashSync(process.argv[2], 12) ..." -- "$ADMIN_PASS"
```
With `node -e` there is **no script-path argument**, so the first user arg lands
at `process.argv[1]` — `argv[2]` was `undefined`. `bcrypt.hashSync(undefined,12)`
throws `Illegal arguments: undefined, string` → exit 1. The `htpasswd` fallback
then also failed (apache2-utils not installed) → `die`. Result: `config.json`
was never written, so PM2/the panel never started.

This was **not** related to skipping `apt upgrade`.

### Fix
- Pass the password via the **`RIXXX_ADMIN_PASS` env var** and read it from
  `process.env` (robust against `node -e` argv quirks *and* special chars).
- `htpasswd` fallback now installs `apache2-utils` first.
- `install_panel`: also look for `$PWD/panel` (covers `sudo bash install.sh`
  from the cloned repo) and wrap `npm install` in a subshell so the caller's cwd
  is preserved.
- `tests/e2e.sh`: Bug 73 regression asserts; CHANGELOG note.

### Verification (sandbox)
- bcrypt hash now generated: 60 chars, `$2a$` prefix, `compareSync` = `true`.
- `write_config_json` simulation writes valid JSON.
- Panel boots and serves **HTTP 200 on `:3000`** with a valid config.
- `bash -n install.sh` / `tests/e2e.sh` pass; 4/4 new regression asserts pass.

### After merging — recovery on the VPS
```sh
cd ~/Panel-Naive-Mieru-by-RIXXX && git pull
sudo bash uninstall.sh --yes      # clean the half-install
sudo bash install.sh --force      # re-run; panel will come up on :3000
```
