### PR TITLE
Bug 75: start mita so it leaves IDLE and binds ports (mieru server fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 75 (P1, mieru server) — mita stayed IDLE, so the proxy never listened
+
+Server logs showed `mita` running but reporting `app status IDLE`, and
+`/var/lib/rixxx-panel/mita-state.json` held the correct port bindings + user — yet
+mieru clients couldn't connect. Root cause: when a user is added via the panel,
+`applyMitaConfig()` ran `mita apply config` followed by `mita reload`. Per the
+upstream docs, **`mita reload` only re-reads the config of an already-RUNNING
+server — it does NOT lift the service from IDLE → RUNNING.** Since the installer
+intentionally does not start mita while `users[]` is empty (Bug 4), the first
+panel-driven config update reloaded an IDLE server that never bound its ports.
+
+**Fix**: `applyMitaConfig()` now checks `mita status`; if RUNNING it `reload`s,
+otherwise it `mita start`s (falling back to `systemctl restart mita`). `install.sh`
+likewise now issues `mita start` (not just a daemon restart) once the first user
+exists, so the proxy actually enters RUNNING and binds 2012–2022.
+
 ### Bug 74 (P1, mieru client config) — generated Mieru config did not connect
 
 Field-tested against a **known-working** Karing/sing-box mieru config from another

--- a/install.sh
+++ b/install.sh
@@ -1045,9 +1045,17 @@ except Exception:
     print(0)
 " 2>/dev/null || echo 0)
   if [[ "$_mita_users" -gt 0 ]]; then
-    systemctl restart mita && \
-      log_info "$(t 'mita запущен ✓' 'mita started ✓')" || \
-      log_warn "$(t 'mita не запустился — journalctl -u mita -n 30' 'mita failed — journalctl -u mita -n 30')"
+    # Bug 75: the daemon (mita run) starting is NOT enough — the proxy stays in
+    # state IDLE until `mita start` is issued. Restart the daemon, then start the
+    # proxy so it actually binds the configured ports.
+    systemctl restart mita 2>/dev/null || true
+    sleep 1
+    if mita start 2>/dev/null; then
+      log_info "$(t 'mita запущен ✓' 'mita started ✓')"
+    else
+      log_warn "$(t 'mita не запустился — journalctl -u mita -n 30 / mita status' \
+                   'mita failed to start — journalctl -u mita -n 30 / mita status')"
+    fi
   else
     log_info "$(t 'mita: нет пользователей — сервис запустится автоматически после добавления первого пользователя' \
                'mita: no users yet — service will start automatically after first user is added via panel')"

--- a/panel/server/index.js
+++ b/panel/server/index.js
@@ -462,7 +462,25 @@ function applyMitaConfig() {
   const file = buildMitaStateFile();
   try {
     execSync(`mita apply config ${file} 2>/dev/null`, { timeout: 15000 });
-    execSync('mita reload 2>/dev/null', { timeout: 15000 });
+
+    // Bug 75: a fresh mita install sits in state IDLE (the installer does NOT
+    // start it while users[] is empty — Bug 4). `mita reload` only re-reads the
+    // config of an already-RUNNING server; it will NOT lift IDLE -> RUNNING, so
+    // the proxy never starts listening and mieru clients can't connect.
+    // Therefore: detect status and `mita start` when IDLE, otherwise `reload`.
+    let status = '';
+    try { status = execSync('mita status 2>/dev/null', { timeout: 10000 }).toString(); }
+    catch { status = ''; }
+
+    if (/RUNNING/i.test(status)) {
+      execSync('mita reload 2>/dev/null', { timeout: 15000 });
+    } else {
+      // IDLE (or unknown): start the service so it binds the configured ports.
+      // Fall back to systemctl restart if `mita start` is unavailable.
+      try { execSync('mita start 2>/dev/null', { timeout: 15000 }); }
+      catch { execSync('systemctl restart mita 2>/dev/null || true', { timeout: 15000 }); }
+    }
+
     shredFile(file + '.last');
     return true;
   } catch { return false; }


### PR DESCRIPTION
## Summary
Fixes the **server-side** half of the mieru no-connection issue (the client-config half was Bug 74, merged in #15).

### Bug 75 — mita stayed IDLE, proxy never listened
Server logs: `mita` running but `app status IDLE`; `/var/lib/rixxx-panel/mita-state.json` had the correct port bindings + user `petya_test` — yet no connection.

**Root cause:** when a user is added via the panel, `applyMitaConfig()` ran `mita apply config` then `mita reload`. Per upstream docs, **`mita reload` only re-reads config of an already-RUNNING server — it does NOT lift IDLE → RUNNING.** The installer intentionally doesn't start mita while `users[]` is empty (Bug 4), so the first panel-driven update reloaded an IDLE server that never bound its ports.

**Fix:**
- `applyMitaConfig()`: check `mita status` → `reload` if RUNNING, else `mita start` (fallback `systemctl restart mita`).
- `install.sh`: after the first user exists, issue `mita start` (not just a daemon restart) so the proxy enters RUNNING.

Verified mita command syntax against the enfein/mieru docs (`mita status` / `start` / `reload` / `apply config` / `describe config`).

## How the user can confirm the fix on the current server (no reinstall needed)
```
mita start          # lift IDLE -> RUNNING (binds 2012-2022)
mita status         # expect: RUNNING
mita describe config
```
After this PR merges, the panel does this automatically on every user add/update.