### PR TITLE
Bug 77: fix real silent-exit in update.sh (check_root/check_install set -e footgun)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 77 (`update.sh`) — **the actual** silent-exit cause: `check_root`/`check_install`
+
+Even after Bug 76's ERR trap, `sudo bash update.sh --force -y` still printed
+**nothing** and returned to the prompt (exit 1). A `bash -x` trace pinned it down:
+the script died immediately after `check_root` at `[[ 0 -ne 0 ]]`.
+
+Root cause — a classic `set -e` footgun. The one-liner functions were:
+```sh
+check_root()    { [[ $EUID -ne 0 ]] && die "Run as root"; }
+check_install() { [[ ! -f "$PANEL_CONFIG" ]] && die "..."; }
+```
+On the **happy path** (running as root / panel installed), the `[[ ]]` test is
+**false**, the `&&` short-circuits, and the test's exit status `1` becomes the
+**function's** return value. When `main` then calls `check_root` as a plain
+command, that non-zero return trips `set -e` → the whole script aborts before
+any `log_*` runs (and the function-return doesn't reliably fire the ERR trap).
+
+**Fix**: rewrote both as explicit `if` blocks ending in `return 0`. Verified with
+`bash -x`: the script now runs end-to-end, copies the panel files, and reports
+`Panel updated ✓ (v1.2.6 markers present)`.
+
 ### Bug 76 (`update.sh`) — update silently did nothing / skipped panel files
 
 After a clean update, the live panel in `/opt/panel-naive-mieru` still ran the

--- a/update.sh
+++ b/update.sh
@@ -118,10 +118,23 @@ EOF
 }
 
 # ── Prerequisite checks ───────────────────────────────────────────────────────
-check_root()    { [[ $EUID -ne 0 ]] && die "Run as root"; }
+# Bug 77: under `set -e`, a function whose LAST statement is `[[ cond ]] && die`
+# returns the exit status of the `[[ ]]` test. On the happy path the test is
+# FALSE → the function returns 1 → the *caller* (e.g. `check_root` in main) is a
+# plain command that exits non-zero → `set -e` aborts the whole script with NO
+# output and the ERR trap on a function return is skipped. This is exactly why
+# `sudo bash update.sh --force -y` printed nothing and returned to the prompt
+# (traced: it died right after `check_root` → `[[ 0 -ne 0 ]]`). Use explicit
+# `if` blocks with a trailing `return 0`.
+check_root() {
+  if [[ $EUID -ne 0 ]]; then die "Run as root"; fi
+  return 0
+}
 check_install() {
-  [[ ! -f "$PANEL_CONFIG" ]] && \
+  if [[ ! -f "$PANEL_CONFIG" ]]; then
     die "Panel not installed. Run install.sh first."
+  fi
+  return 0
 }
 
 load_config() {


### PR DESCRIPTION
## The real root cause of the silent `update.sh` exit
Even with Bug 76's ERR trap, `sudo bash update.sh --force -y` still printed **nothing** and returned to the prompt (exit 1). A `bash -x` trace pinned it exactly:
```
+ check_root
+ [[ 0 -ne 0 ]]
   <script dies here, exit 1, no output>
```

### Why
Classic `set -e` footgun. The one-liner check functions were:
```sh
check_root()    { [[ $EUID -ne 0 ]] && die "Run as root"; }
check_install() { [[ ! -f "$PANEL_CONFIG" ]] && die "..."; }
```
On the **happy path** (root / panel installed), the `[[ ]]` test is **false**, `&&` short-circuits, and the test's exit status `1` becomes the **function's return value**. When `main` calls `check_root` as a plain command, that non-zero return trips `set -e` and the whole script aborts **before any `log_*` output** — and a function-return doesn't reliably fire the ERR trap.

### Fix
Rewrote both as explicit `if` blocks ending in `return 0`.

### Verified (sandbox, with a valid config present)
```
▶ Updating Panel Naive + Mieru to v1.2.6
▶ Updating web panel
[INFO] Fetched latest panel from <repo>
[INFO] Panel updated ✓ (v1.2.6 markers present)
```
`grep -c downloadNote /opt/.../public/index.html` → `1` (new code landed).

## After this merges — the user's update will finally work
```
cd ~/Panel-Naive-Mieru-by-RIXXX
git pull origin main
sudo bash update.sh --force -y     # now runs end-to-end, copies panel files
grep -c downloadNote /opt/panel-naive-mieru/public/index.html   # expect 1
pm2 restart panel-naive-mieru --update-env
```
Then hard-refresh the browser (Ctrl+Shift+R).