### PR TITLE
fix(install/update): Bug 79 — caddy-naive 'Caddyfile: permission denied' (P1 Naive disabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 79 (`install.sh` + `update.sh`) — caddy-naive "Caddyfile: permission denied"
+
+**P1 — Naive shown as disabled in the panel.** On the live server `caddy-naive`
+was in a `failed` state, restart-looping with:
+```
+Error: reading config from file: open /etc/caddy-naive/Caddyfile: permission denied
+```
+
+Root cause — a directory-traversal permission bug. The service runs as
+`User=caddy`, but the installer set up `/etc/caddy-naive` with
+`chgrp caddy + chmod -R g+r + chmod 640 Caddyfile`. That gives the **group** read
+on the files, but a **640 directory** (`drw-r-----`) has **no execute (x) bit for
+the group**, so the `caddy` user cannot *traverse* the directory to open the file
+inside it — hence "permission denied", even though the file's own perms looked OK.
+
+**Fix** (both scripts):
+- Own the whole config dir as `root:caddy`.
+- Directory → **750** (`rwxr-x---`, group can traverse + list).
+- Files → **640** (`rw-r-----`, group can read).
+- Order matters: chmod the top dir to 750 **first**, then `find` the contents
+  (a 640 dir can't be descended into by `find`). Verified in a sandbox.
+- `update.sh` gains a `fix_caddy_perms()` helper, called from
+  `rebuild_caddyfile_direct`, `do_repair`, and `do_update` (which now also
+  restarts caddy-naive), so existing broken installs self-heal on update.
+
 ### Bug 78 (panel) — Monitoring traffic always 0 + selectable Mieru port
 
 **P2 — traffic never updated.** Both `/api/stats/users` and the 60-second traffic

--- a/install.sh
+++ b/install.sh
@@ -991,8 +991,23 @@ start_services() {
   chown root:caddy "$CADDY_BIN" 2>/dev/null || true
   chmod 755 "$CADDY_BIN" 2>/dev/null || true
   setcap 'cap_net_bind_service=+ep' "$CADDY_BIN" 2>/dev/null || true
-  chgrp -R caddy "$CADDY_CONFIG_DIR" 2>/dev/null || true
-  chmod -R g+r  "$CADDY_CONFIG_DIR" 2>/dev/null || true
+
+  # Bug 79: caddy-naive runs as User=caddy and failed at startup with
+  #   "reading config from file: open /etc/caddy-naive/Caddyfile: permission denied".
+  #   The previous `chgrp caddy + chmod g+r + chmod 640` set the GROUP and read
+  #   bits on files, but a 640 directory (drw-r-----) has NO execute (x) bit for
+  #   the group, so the caddy user cannot *traverse* the dir to open the file.
+  #   Fix: own the whole config dir as root:caddy, give the DIRECTORY 750
+  #   (rwxr-x---, group can traverse + read) and the secret/config FILES 640.
+  chown -R root:caddy "$CADDY_CONFIG_DIR" 2>/dev/null || true
+  # Order matters: make the top dir traversable FIRST, otherwise `find` cannot
+  # descend into a 640 dir to chmod the files inside it.
+  chmod 750 "$CADDY_CONFIG_DIR" 2>/dev/null || true
+  # Directories: 750 so the caddy group can enter and list them.
+  find "$CADDY_CONFIG_DIR" -type d -exec chmod 750 {} + 2>/dev/null || true
+  # Files: 640 so the caddy group can read them (no write, no exec).
+  find "$CADDY_CONFIG_DIR" -type f -exec chmod 640 {} + 2>/dev/null || true
+  # Belt-and-suspenders: ensure the Caddyfile is right.
   chmod 640 "$CADDY_FILE" 2>/dev/null || true
 
   systemctl daemon-reload

--- a/update.sh
+++ b/update.sh
@@ -352,6 +352,8 @@ rebuild_caddyfile_direct() {
       return 1
     fi
   fi
+  # Bug 79: ensure the caddy user can actually read the freshly-written file
+  fix_caddy_perms
   log_info "Caddyfile rebuilt ✓"
 }
 
@@ -448,6 +450,29 @@ SVCCADDY
     rm -f /etc/systemd/system/naive.service
     log_info "Legacy naive.service removed (replaced by caddy-naive.service)"
   fi
+}
+
+# ── Bug 79: fix caddy-naive config permissions ───────────────────────────────
+#   caddy-naive runs as User=caddy and fails to start with
+#     "reading config from file: open /etc/caddy-naive/Caddyfile: permission denied"
+#   when the config dir lacks group-execute (traverse) for the caddy group.
+#   The Caddyfile is written by root (mode 640, owner root:root); the caddy user
+#   then cannot enter the dir / read the file. Own dir as root:caddy, set dirs
+#   750 (group can traverse) and files 640 (group can read).
+fix_caddy_perms() {
+  id caddy &>/dev/null || return 0
+  [[ -d "$CADDY_CONFIG_DIR" ]] || return 0
+  chown -R root:caddy "$CADDY_CONFIG_DIR" 2>/dev/null || true
+  # Order matters: make the top dir traversable FIRST, otherwise `find` cannot
+  # descend into a 640 dir to chmod the files inside it.
+  chmod 750 "$CADDY_CONFIG_DIR" 2>/dev/null || true
+  find "$CADDY_CONFIG_DIR" -type d -exec chmod 750 {} + 2>/dev/null || true
+  find "$CADDY_CONFIG_DIR" -type f -exec chmod 640 {} + 2>/dev/null || true
+  [[ -f "$CADDY_FILE" ]] && chmod 640 "$CADDY_FILE" 2>/dev/null || true
+  # caddy also needs its data/log dirs owned correctly
+  mkdir -p /var/log/caddy-naive /var/lib/caddy 2>/dev/null || true
+  chown -R caddy:caddy /var/log/caddy-naive /var/lib/caddy 2>/dev/null || true
+  log_info "caddy-naive config permissions fixed (dir 750, files 640, owner root:caddy) ✓"
 }
 
 # ── v1.2.3: Update caddy-forwardproxy-naive (amd64 only) ─────────────────────
@@ -868,6 +893,8 @@ FAKEHTML
 
   # Step 5: reload/restart services
   systemctl daemon-reload
+  # Bug 79: make sure the caddy user can read its config before (re)starting
+  fix_caddy_perms
   systemctl reload caddy-naive 2>/dev/null || \
     systemctl restart caddy-naive 2>/dev/null && \
     log_info "caddy-naive reloaded ✓" || \
@@ -918,6 +945,13 @@ do_update() {
   ensure_caddy_service
 
   $DRY_RUN && { log_info "[DRY-RUN] No changes were made."; return; }
+
+  # Bug 79: fix caddy-naive config permissions and (re)start it. Older installs
+  # left /etc/caddy-naive at 640 (no group-execute), so caddy-naive failed with
+  # "Caddyfile: permission denied". Fix perms then restart so the fix takes hold.
+  fix_caddy_perms
+  systemctl restart caddy-naive 2>/dev/null && log_info "caddy-naive restarted ✓" || \
+    log_warn "caddy-naive restart failed — journalctl -u caddy-naive -n 20"
 
   # Update version file
   if [[ -f "$VERSION_FILE" ]]; then


### PR DESCRIPTION
## P1 — Naive shown as disabled (ROOT CAUSE FOUND & FIXED)

On the live server `caddy-naive` was in a **failed** state, restart-looping with:
```
Error: reading config from file: open /etc/caddy-naive/Caddyfile: permission denied
```

### Root cause — directory traversal permission bug
The service runs as `User=caddy`. The installer set up `/etc/caddy-naive` with:
```sh
chgrp -R caddy /etc/caddy-naive
chmod -R g+r   /etc/caddy-naive
chmod 640      /etc/caddy-naive/Caddyfile
```
That gives the **group** read on the files, but a **640 directory** (`drw-r-----`) has **no execute (x) bit for the group**, so the `caddy` user cannot *traverse* the directory to open the file inside it → "permission denied", even though the file's own perms looked fine.

### Fix (both scripts)
- Own the whole config dir as `root:caddy`.
- **Directory → 750** (`rwxr-x---`, group can traverse + list).
- **Files → 640** (`rw-r-----`, group can read).
- **Order matters:** chmod the top dir to 750 **first**, then `find` the contents — a 640 dir can't be descended into by `find`. Verified in a sandbox.
- `update.sh` gains a `fix_caddy_perms()` helper, called from `rebuild_caddyfile_direct`, `do_repair`, and `do_update` (which now also restarts caddy-naive) so **existing broken installs self-heal on update**.

## Testing
- `bash -n install.sh` + `bash -n update.sh` — OK
- Sandbox repro: a 640 dir blocks traversal; after the fix dir=750 / files=640. Confirmed.

## Note for the owner
After merging, run `update.sh` on the server — it will fix the perms and restart caddy-naive automatically. Then `systemctl is-active caddy-naive` should report `active`.