### PR TITLE
fix(install/update): Bug 79b — caddy-naive Caddyfile root:root + restart failure storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 79b (`install.sh` + `update.sh`) — caddy-naive perms follow-up
+
+Live-server diagnostics after Bug 79 showed the config **directory** was actually
+fine (`drwxr-xr-x root caddy`), but the **Caddyfile itself was owned `root:root`**
+(`-rw-r----- root root`) — so the caddy group's read bit was useless and the
+service still failed with `permission denied`. Two follow-ups:
+
+1. The real fix is the `chown -R root:caddy` already in `fix_caddy_perms()`; the
+   earlier update simply hadn't shipped it yet (stale local clone).
+2. **Failure-storm + ordering:** `update_caddy_naive` reinstalled the binary and
+   immediately `systemctl start`ed it *before* perms were fixed, tripping the
+   5-in-5-min restart limit (`Start request repeated too quickly`), so the later
+   `fix_caddy_perms` couldn't recover the service. Fixes:
+   - `update_caddy_naive` now calls `fix_caddy_perms` + `systemctl reset-failed`
+     **before** starting caddy after a binary reinstall (also re-applies setcap,
+     which `install` strips).
+   - `do_update` and `install.sh start_services` add `systemctl reset-failed`
+     before the (re)start.
+
 ### Bug 79 (`install.sh` + `update.sh`) — caddy-naive "Caddyfile: permission denied"
 
 **P1 — Naive shown as disabled in the panel.** On the live server `caddy-naive`

--- a/install.sh
+++ b/install.sh
@@ -1014,6 +1014,9 @@ start_services() {
 
   # ── 5. caddy-naive (Bug 61: non-fatal — continue if Caddy fails) ─────────────
   systemctl enable caddy-naive
+  # Bug 79b: clear any prior failure storm so restart isn't blocked by
+  # "Start request repeated too quickly" after we've just fixed perms/caps.
+  systemctl reset-failed caddy-naive 2>/dev/null || true
   systemctl restart caddy-naive || true
   sleep 2
   if systemctl is-active --quiet caddy-naive; then

--- a/update.sh
+++ b/update.sh
@@ -542,6 +542,11 @@ update_caddy_naive() {
     if command -v setcap &>/dev/null; then
       setcap 'cap_net_bind_service=+ep' "$CADDY_BIN" 2>/dev/null || true
     fi
+    # Bug 79b: fix config perms BEFORE starting, and clear any prior failure
+    # storm — otherwise a broken-perms install hits "Start request repeated too
+    # quickly" and never recovers even after the perms are fixed later.
+    fix_caddy_perms
+    systemctl reset-failed caddy-naive 2>/dev/null || true
     systemctl start caddy-naive 2>/dev/null || true
     log_info "caddy-naive updated to $remote_tag ✓"
   else
@@ -947,9 +952,11 @@ do_update() {
   $DRY_RUN && { log_info "[DRY-RUN] No changes were made."; return; }
 
   # Bug 79: fix caddy-naive config permissions and (re)start it. Older installs
-  # left /etc/caddy-naive at 640 (no group-execute), so caddy-naive failed with
-  # "Caddyfile: permission denied". Fix perms then restart so the fix takes hold.
+  # left the Caddyfile owned root:root (group caddy couldn't read it), so
+  # caddy-naive failed with "Caddyfile: permission denied". Fix perms, clear any
+  # failure storm (reset-failed), then restart so the fix actually takes hold.
   fix_caddy_perms
+  systemctl reset-failed caddy-naive 2>/dev/null || true
   systemctl restart caddy-naive 2>/dev/null && log_info "caddy-naive restarted ✓" || \
     log_warn "caddy-naive restart failed — journalctl -u caddy-naive -n 20"
 


### PR DESCRIPTION
## Follow-up to Bug 79 — caddy-naive still failed after the first update

Live-server diagnostics revealed the precise cause and a second issue:

### 1. Caddyfile owned root:root (not root:caddy)
The config **directory** was already fine:
```
drwxr-xr-x root caddy  /etc/caddy-naive
```
…but the **file** was owned root:root:
```
-rw-r----- root root  Caddyfile      ← group caddy can't read it
-rw-r----- root caddy probe_secret
```
So the `640` group-read bit was useless. The real fix (`chown -R root:caddy`) was already in `fix_caddy_perms()` from Bug 79 — it just hadn't reached the server (stale local clone). After `git reset --hard origin/main` + a manual chown, caddy-naive went **active**.

### 2. Failure storm + ordering
`update_caddy_naive` reinstalled the binary and `systemctl start`ed caddy **before** perms were fixed, tripping the 5-in-5-min restart limit (`Start request repeated too quickly`). The later `fix_caddy_perms` then couldn't recover the unit.

### Fixes
- `update_caddy_naive`: call `fix_caddy_perms` + `systemctl reset-failed` **before** starting caddy after a binary reinstall (also re-applies `setcap`, which `install` strips).
- `do_update` and `install.sh start_services`: `systemctl reset-failed caddy-naive` before the (re)start.

## Testing
- `bash -n install.sh` + `bash -n update.sh` — OK
- Confirmed live: after the manual equivalent (chown root:caddy + setcap + reset-failed + restart), `systemctl is-active caddy-naive` = **active**.

## Owner note
The server is already fixed manually. After merging, the next `update.sh` will keep it healthy automatically (perms + reset-failed are now built in).