### PR TITLE
fix: node -e couldn't find better-sqlite3 — Caddyfile rebuild crashed on update (Bug 82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 82 (`update.sh` + `install.sh`) — `node -e` couldn't find `better-sqlite3`
+
+Live update showed the Caddyfile rebuild crashing with
+`Error: Cannot find module 'better-sqlite3'`, so the config was **not** regenerated
+(stale Caddyfile kept the old secret + missing protocols block). Cause: the inline
+`node -e "…"` scripts run with cwd = the git checkout (`~/Panel-Naive-Mieru-by-RIXXX`),
+which has no `node_modules`; the modules live under `$PANEL_DIR`
+(`/opt/panel-naive-mieru`). Fix: wrap the DB-reading `node -e` blocks in
+`( cd "$PANEL_DIR" && node -e "…" )` so Node resolves `better-sqlite3` and the
+template correctly.
+- `update.sh`: `rebuild_caddyfile_direct()` and `rebuild_mita_state_direct()`.
+- `install.sh`: the `naive_users_json` reader (its silent `try/catch` previously
+  meant a `--force` reinstall could quietly drop all naive users).
+
 ### Bug 81b (`update.sh`) — migrate existing installs to bare + regenerate on update
 
 Follow-up after live testing: `--force` update did **not** regenerate the Caddyfile

--- a/install.sh
+++ b/install.sh
@@ -564,7 +564,9 @@ write_caddyfile() {
   # Bug 23: credential lines are  basic_auth <user> <pass>  (no bare keyword)
   local naive_users_json="[]"
   if [[ -f "$DB_PATH" ]] && command -v node &>/dev/null; then
-    naive_users_json=$(node -e "
+    # Bug 82: run from $PANEL_DIR so better-sqlite3 resolves (else the try/catch
+    # silently returns [] and a --force reinstall would drop all naive users).
+    naive_users_json=$(cd "$PANEL_DIR" 2>/dev/null && node -e "
       try {
         const Database = require('better-sqlite3');
         const db = new Database('$DB_PATH', { readonly: true });

--- a/update.sh
+++ b/update.sh
@@ -271,7 +271,10 @@ rebuild_caddyfile_direct() {
 
   local template_js="${PANEL_DIR}/server/caddyTemplate.js"
 
-  node -e "
+  # Bug 82: run node from the panel dir so it can resolve better-sqlite3 and the
+  # other node_modules (they live under $PANEL_DIR, not the script's cwd which is
+  # the git checkout — that has no node_modules → "Cannot find module").
+  ( cd "$PANEL_DIR" && node -e "
     const Database = require('better-sqlite3');
     const fs       = require('fs');
     const path     = require('path');
@@ -368,7 +371,7 @@ rebuild_caddyfile_direct() {
     fs.renameSync(tmp, '$CADDY_FILE');
     console.log('[Caddyfile] rebuilt with', naiveUsers.length, 'user(s)');
     db.close();
-  " || {
+  " ) || {
     log_warn "Node Caddyfile rebuild failed — Caddyfile will be rebuilt on next panel operation"
     return 1
   }
@@ -394,7 +397,8 @@ rebuild_mita_state_direct() {
   log_step "Rebuilding mita-state.json from database"
   [[ ! -f "$DB_PATH" ]] && { log_warn "DB not found — skipping mita state rebuild"; return; }
 
-  node -e "
+  # Bug 82: run node from the panel dir so better-sqlite3 resolves correctly.
+  ( cd "$PANEL_DIR" && node -e "
     const Database = require('better-sqlite3');
     const fs       = require('fs');
     const db       = new Database('$DB_PATH', { readonly: true });
@@ -429,7 +433,7 @@ rebuild_mita_state_direct() {
     fs.renameSync(tmp, '$MITA_STATE_FILE');
     console.log('[mita-state] wrote', users.length, 'user(s)');
     db.close();
-  " 2>/dev/null || {
+  " ) 2>/dev/null || {
     log_warn "Node mita state rebuild failed"
     return 1
   }


### PR DESCRIPTION
## Problem (live update)

`update.sh --force` did the config migration (`probeMode='bare' ✓`) but the **Caddyfile rebuild crashed**:
```
▶ Rebuilding Caddyfile from SQLite database
Error: Cannot find module 'better-sqlite3'
[WARN] Node Caddyfile rebuild failed — Caddyfile will be rebuilt on next panel operation
```
So `/etc/caddy-naive/Caddyfile` was **not** regenerated and still showed the old `probe_resistance <secret>` and no `servers { protocols h1 h2 }`.

### Root cause
The inline `node -e "…"` scripts run with cwd = the git checkout (`~/Panel-Naive-Mieru-by-RIXXX`), which has **no `node_modules`**. The modules are installed under `$PANEL_DIR` (`/opt/panel-naive-mieru`), so `require('better-sqlite3')` failed.

## Fix (Bug 82)
Wrap the DB-reading `node -e` blocks in `( cd "$PANEL_DIR" && node -e "…" )`:
- `update.sh`: `rebuild_caddyfile_direct()` + `rebuild_mita_state_direct()`
- `install.sh`: the `naive_users_json` reader (its silent `try/catch` previously meant a `--force` reinstall could quietly drop all naive users)

## Testing
- `bash -n update.sh && bash -n install.sh` ✓
- **End-to-end**: ran the real rebuild node logic with cwd=panel dir against a test DB (2 users) + migrated config → generated Caddyfile has `protocols h1 h2`, **both users preserved**, and **bare `probe_resistance`** ✓

## Apply on server (after merge)
```
cd ~/Panel-Naive-Mieru-by-RIXXX && git pull
sudo bash update.sh --force -y
sudo cat /etc/caddy-naive/Caddyfile   # protocols block + bare probe_resistance, users intact
```