### PR TITLE
fix(update.sh): --repair rebuilds Caddyfile directly, not via stale panel API (Bug 84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 84 (`update.sh`) — `--repair` regenerated a STALE Caddyfile via the panel API
+
+After Bug 83 was merged and deployed (the on-disk `caddyTemplate.js` in
+`$PANEL_DIR` was confirmed to be the new format, 7346 bytes), the live
+`/etc/caddy-naive/Caddyfile` was *still* the old layout (`route {}` wrapper,
+domain-only listener) even though the rebuild reported success.
+
+Root cause: `do_repair` POSTed to `/api/services/rebuild-all` **first**, which is
+rendered by the **running PM2 panel process** using its *in-memory* `buildCaddyfile()`
+from `index.js`. If that process hadn't reloaded the new `index.js` yet, the API
+regenerated the OLD Caddyfile format — and the `rebuild_caddyfile_direct` fallback
+(which uses the on-disk template, the single source of truth) **never ran** because
+the API call "succeeded". So the new template on disk was ignored.
+
+Fix: `do_repair` now **always** calls `rebuild_caddyfile_direct` /
+`rebuild_mita_state_direct` directly, dropping the API-first path. The rebuilt
+Caddyfile therefore always reflects `$PANEL_DIR/server/caddyTemplate.js` regardless
+of whatever code the panel happens to have loaded in memory. (`do_update` already
+used the direct rebuild and restarts PM2 with `--update-env`, so it was unaffected.)
+
 ### Bug 83 (`panel` + `install.sh` + `update.sh`) — Caddyfile site block to match reference exactly
 
 Live testing: even after Bug 80/81 the naive key still wouldn't connect, while the

--- a/update.sh
+++ b/update.sh
@@ -922,14 +922,18 @@ FAKEHTML
   ensure_caddy_service
 
   # Step 3: rebuild Caddyfile + mita state from DB
-  # Try API first (preserves running state), fall back to direct rebuild
-  if curl -sf http://127.0.0.1:3000/api/services/rebuild-all \
-       -X POST -b /tmp/.repair-cookie 2>/dev/null | grep -q '"ok":true'; then
-    log_info "Config rebuild via API ✓"
-  else
-    rebuild_caddyfile_direct
-    rebuild_mita_state_direct
-  fi
+  # Bug 84: ALWAYS rebuild directly from the on-disk caddyTemplate.js (the single
+  # source of truth that --update freshly copied into $PANEL_DIR). Previously
+  # --repair POSTed to /api/services/rebuild-all FIRST, which is rendered by the
+  # *running* PM2 panel process. If that process had not reloaded the new
+  # index.js yet (e.g. update_panel copied the files but the panel was still
+  # serving old in-memory code), the API regenerated the STALE Caddyfile format
+  # (route{} wrapper, domain-only listener) even though the on-disk template was
+  # already the new Bug 83 layout — and the direct fallback never ran because the
+  # API "succeeded". Going direct guarantees the rebuilt Caddyfile reflects the
+  # template on disk, independent of whatever code the panel happens to be running.
+  rebuild_caddyfile_direct
+  rebuild_mita_state_direct
 
   # Step 4: apply mita config
   if [[ -f "$MITA_STATE_FILE" ]]; then


### PR DESCRIPTION
## Bug 84 — `--repair` regenerated a STALE Caddyfile via the panel API

### Symptom
After Bug 83 was merged + deployed (on-disk `caddyTemplate.js` in `$PANEL_DIR` confirmed new, 7346 bytes), the live `/etc/caddy-naive/Caddyfile` was **still** the old layout (`route {}` wrapper, domain-only listener) even though the rebuild reported success.

### Root cause
`do_repair` POSTed to `/api/services/rebuild-all` **first**, which is rendered by the **running PM2 panel** using its *in-memory* `buildCaddyfile()` from `index.js`. If that process had not reloaded the new `index.js`, the API regenerated the OLD format — and the `rebuild_caddyfile_direct` fallback (which uses the on-disk template, the single source of truth) **never ran** because the API call succeeded.

### Fix
`do_repair` now **always** calls `rebuild_caddyfile_direct` + `rebuild_mita_state_direct` directly, dropping the API-first path. The rebuilt Caddyfile always reflects `$PANEL_DIR/server/caddyTemplate.js` regardless of the panel`s in-memory code. (`do_update` already used the direct rebuild + restarts PM2 with `--update-env`, so it was unaffected.)

### Verification
- `bash -n update.sh`, `node --check` on index.js + caddyTemplate.js — all pass.
- Template render for jazz.magniysovetuy.site produces the exact Bug 83 reference layout (`:443, <domain> { tls <email>; forward_proxy {...}; file_server {...} }`, no route wrapper, protocols h1 h2, bare probe_resistance).