### PR TITLE
fix(update.sh): --repair exited 1 silently (parse_args return under set -e) (Bug 85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.6] — 2026-05-29
 
+### Bug 85 (`update.sh`) — `--repair` (and `--status`/`--expose`/`--ssh-only`) exited 1 SILENTLY before doing anything
+
+Live testing: `sudo bash update.sh --repair -y` returned `EXIT=1` with **zero
+output** and the Caddyfile was never rebuilt (still the old Bug 83-era layout),
+so Bug 84's direct rebuild never even ran.
+
+Root cause — the classic Bug 77 `set -e` trap: the **last** statement of
+`parse_args` was
+```bash
+[[ -z "$MODE" ]] && MODE="update"
+```
+When a mode flag was supplied (e.g. `--repair` → `MODE="repair"`), the test
+`[[ -z "repair" ]]` is FALSE, so `parse_args` **returned 1**. In `main()`,
+`parse_args "$@"` is a plain command → `set -euo pipefail` aborted the whole
+script immediately, and because the failure was a function *return* the `ERR`
+trap was skipped → no message at all. This only hit mode flags; a bare update
+left `MODE` empty, so the test was TRUE → return 0 → it worked (which is why
+`--force -y` always ran but `--repair` never did).
+
+Fix: replace the trailing one-liner with an explicit `if` block and a trailing
+`return 0`:
+```bash
+if [[ -z "$MODE" ]]; then MODE="update"; fi
+return 0
+```
+Now `--repair`/`--status`/`--expose`/`--ssh-only` reach their handlers, and with
+Bug 84 `--repair` rebuilds the Caddyfile directly from the on-disk template.
+
 ### Bug 84 (`update.sh`) — `--repair` regenerated a STALE Caddyfile via the panel API
 
 After Bug 83 was merged and deployed (the on-disk `caddyTemplate.js` in

--- a/update.sh
+++ b/update.sh
@@ -85,7 +85,16 @@ parse_args() {
     esac
     shift
   done
-  [[ -z "$MODE" ]] && MODE="update"
+  # Bug 85: under `set -e`, this `[[ ]] && ...` was the LAST statement in
+  # parse_args. When a MODE flag was given (e.g. --repair), the test
+  # `[[ -z "repair" ]]` is FALSE, so parse_args RETURNED 1 → the caller in
+  # main() (`parse_args "$@"`) is a plain command that exits non-zero →
+  # `set -e` aborted the whole script with NO output, and the ERR trap on a
+  # function return is skipped (exactly the Bug 77 failure mode). This is why
+  # `--repair` exited 1 silently while `--force -y` (MODE empty → test TRUE →
+  # return 0) worked. Use an explicit `if` + trailing `return 0`.
+  if [[ -z "$MODE" ]]; then MODE="update"; fi
+  return 0
 }
 
 print_help() {


### PR DESCRIPTION
## Bug 85 — `--repair` exited 1 silently and never rebuilt the Caddyfile

### Symptom (live test)
`sudo bash update.sh --repair -y` returned EXIT=1 with zero output; Caddyfile unchanged (old route wrapper). Bug 84 fix never ran.

### Root cause (Bug 77 set -e trap, again)
The last statement of parse_args was `[[ -z "$MODE" ]] && MODE="update"`. With a mode flag (e.g. --repair) MODE is non-empty, so the test is FALSE and parse_args returns 1. In main(), `parse_args "$@"` is a plain command so `set -euo pipefail` aborts the script, and because it is a function return the ERR trap is skipped (no message). A bare update left MODE empty (test TRUE, return 0), which is why --force -y worked but --repair never did.

### Fix
Use an explicit if-block plus a trailing `return 0` so parse_args always succeeds. --repair/--status/--expose/--ssh-only now reach their handlers; with Bug 84, --repair rebuilds the Caddyfile directly from the on-disk caddyTemplate.js.

### Verification
- bash -n update.sh passes.
- Simulated parse_args with MODE=repair under set -euo pipefail returns 0.

### Next on server (after merge)
cd ~/Panel-Naive-Mieru-by-RIXXX && git pull
sudo bash update.sh --repair -y
sudo head -40 /etc/caddy-naive/Caddyfile  (expect ':443, jazz... { tls ...; forward_proxy {...}; ... }')