### PR TITLE
feat(hy2): Sub-stage C — upgrade migration (update.sh/install.sh) [v1.8.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.8.0]
 
-> **FEATURE — Hysteria2 UI + WARP compatibility (continuation of v1.7.0).**
-> Completes the Hy2 frontend and makes Hy2/QUIC work through Cloudflare WARP.
+> **FEATURE — Hysteria2 UI + WARP compatibility + upgrade migration
+> (continuation of v1.7.0).** Completes the Hy2 frontend, makes Hy2/QUIC work
+> through Cloudflare WARP, and makes existing installs upgrade cleanly — the
+> "Доустановить Hy2" button appears after a plain `update.sh` with **zero data
+> loss** (existing users, protocols, Naive/Mieru configs are untouched).
 
 ### Added
+- **Upgrade migration (Sub-stage C)** — `update.sh` / `install.sh`:
+  - `migrate_config`: backfills `hy2Port` (443/udp) and `stack.{naive,mieru,hy2}`
+    into `config.json` for pre-Hy2 installs. **`stack.hy2` defaults to `false` —
+    the update NEVER auto-installs Hy2**; it only makes the install card
+    available in Settings. Idempotent — custom `hy2Port` / operator-enabled
+    `stack.hy2=true` are preserved via jq `//` fallbacks. Existing `users` and
+    their `protocols` arrays are left completely untouched.
+  - `migrate_hy2`: on update, restarts `hysteria-server` **only if Hy2 is
+    installed** (config.yaml + binary present); otherwise prints a one-line
+    "Доустановить Hy2" hint. `do_repair` likewise restarts Hy2 when installed
+    (the panel re-syncs the `userpass` map from the SQLite pool → no user loss).
+  - `update_panel`: `chmod +x` the shipped `install_hysteria.sh` /
+    `warp_egress.sh` / `cascade_mieru.sh` helpers (both `$PANEL_DIR/scripts` and
+    the legacy `$PANEL_DIR/panel/scripts` layouts) so the panel can run them.
+  - `do_status`: adds a `hysteria (Hy2)` version line, a hysteria-server
+    active/inactive (or "not installed") indicator, and `hy2Port`/`stack` in the
+    config dump.
+  - `install.sh`: fresh installs write the same Hy2 config defaults
+    (`hy2Port: 443`, `stack.hy2: false`) — Hy2 added later from the panel.
 - **Full Hy2 frontend (Sub-stage B-UI):**
   - Dashboard: Hy2 service card (auto-shown when installed) with status badge
     and start/stop/restart service buttons.
@@ -33,9 +55,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   OUTPUT; teardown mirrors the deletes. Hy2's own outbound dials still egress
   via WARP.
 
-### Notes
-- Sub-stage C (`update.sh` migration for existing installs — "Доустановить Hy2")
-  is **still pending** and tracked for a follow-up commit.
+### Tests
+- **`tests/feat-hy2-migration.test.js`** (40 assertions): validates the
+  update.sh/install.sh Hy2 migration (config backfill, idempotency, users
+  preserved), the Hy2 restart-only-when-installed logic, do_status wiring, the
+  server runtime backfill + `/api/settings/hy2`, and the Sub-stage D WARP UDP
+  reply-path rules (incl. that the BUG-171 TCP rule is untouched). Wired into
+  `npm test`. Full suite: **18 files, all green, 0 failed.**
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1232,6 +1232,12 @@ write_config_json() {
       naivePort:      num(E.CFG_NAIVE_PORT, 8443),
       mieruPortStart: num(E.CFG_MIERU_PORT_START, 2012),
       mieruPortEnd:   num(E.CFG_MIERU_PORT_END, 2022),
+      // v1.8.0: Hysteria2 (Hy2) — the optional 3rd protocol. Fresh installs ship
+      // the config defaults but DO NOT install Hy2 (stack.hy2=false). The operator
+      // adds it later from the panel (Settings → «Доустановить Hy2»); it defaults
+      // to 443/udp and reuses the Caddy certificate (no second ACME email).
+      hy2Port:        num(E.CFG_HY2_PORT, 443),
+      stack:          { naive: true, mieru: true, hy2: false },
       panelPort:      3000,
       panelHost:      "127.0.0.1",
       exposePanel:    E.CFG_EXPOSE_PANEL === "1",

--- a/panel/package.json
+++ b/panel/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server/index.js",
     "dev": "node server/index.js",
-    "test": "node ../tests/migration-bug149.test.js && node ../tests/race-bug149.test.js && node ../tests/version-bug143.test.js && node ../tests/bug155-basicauth.test.js && node ../tests/bug156-trafficpattern.test.js && node ../tests/bug-naive-caddylog.test.js && node ../tests/bug-naive-traffic.test.js && node ../tests/bug162-warp-routing.test.js && node ../tests/bug164-warp-oneway.test.js && node ../tests/bug166-warp-register.test.js && node ../tests/bug169-warp-fwmark.test.js && node ../tests/bug170-warp-mss.test.js && node ../tests/bug171-warp-inbound-reply.test.js && node ../tests/bug172-cascade-watchdog.test.js && node ../tests/feat-mieru-link.test.js && node ../tests/feat-backup.test.js && node ../tests/feat-hy2-link.test.js"
+    "test": "node ../tests/migration-bug149.test.js && node ../tests/race-bug149.test.js && node ../tests/version-bug143.test.js && node ../tests/bug155-basicauth.test.js && node ../tests/bug156-trafficpattern.test.js && node ../tests/bug-naive-caddylog.test.js && node ../tests/bug-naive-traffic.test.js && node ../tests/bug162-warp-routing.test.js && node ../tests/bug164-warp-oneway.test.js && node ../tests/bug166-warp-register.test.js && node ../tests/bug169-warp-fwmark.test.js && node ../tests/bug170-warp-mss.test.js && node ../tests/bug171-warp-inbound-reply.test.js && node ../tests/bug172-cascade-watchdog.test.js && node ../tests/feat-mieru-link.test.js && node ../tests/feat-backup.test.js && node ../tests/feat-hy2-link.test.js && node ../tests/feat-hy2-migration.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/tests/feat-hy2-migration.test.js
+++ b/tests/feat-hy2-migration.test.js
@@ -1,0 +1,203 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// v1.8.0 — Hy2 Sub-stage C (update.sh migration) + Sub-stage D (WARP UDP reply
+// path). Verifies that upgrading an EXISTING Naive+Mieru install to the Hy2
+// build:
+//   • backfills config.json with hy2Port (443/udp) + stack.{naive,mieru,hy2}
+//     WITHOUT ever auto-installing Hy2 (stack.hy2 stays false) and WITHOUT
+//     touching existing users / their protocols → nothing breaks;
+//   • makes the "Доустановить Hy2" install card appear (server reports
+//     installed:false → UI renders the install state);
+//   • restarts hysteria-server on update/repair ONLY when Hy2 is installed;
+//   • ships the install_hysteria.sh helper executable;
+//   • fresh installs (install.sh) write the same Hy2 config defaults;
+//   • WARP (Sub-stage D) marks the inbound-UDP reply path so Hy2/QUIC replies
+//     stay on the native route (mirror of the BUG-171 TCP fix), teardown clean.
+//
+// Pure static/regex + jq/node execution — no root, no live services required.
+// ─────────────────────────────────────────────────────────────────────────────
+'use strict';
+const fs   = require('fs');
+const path = require('path');
+const cp   = require('child_process');
+
+let pass = 0, fail = 0;
+const ok = (c, m) => { if (c) { pass++; console.log('  \u2713 ' + m); } else { fail++; console.log('  \u2717 ' + m); } };
+
+const ROOT       = path.join(__dirname, '..');
+const UPDATE_SH  = path.join(ROOT, 'update.sh');
+const INSTALL_SH = path.join(ROOT, 'install.sh');
+const WARP_SH    = path.join(ROOT, 'panel', 'scripts', 'warp_egress.sh');
+const SERVER_JS  = path.join(ROOT, 'panel', 'server', 'index.js');
+
+const upSrc     = fs.readFileSync(UPDATE_SH, 'utf8');
+const instSrc   = fs.readFileSync(INSTALL_SH, 'utf8');
+const warpSrc   = fs.readFileSync(WARP_SH, 'utf8');
+const serverSrc = fs.readFileSync(SERVER_JS, 'utf8');
+
+const hasJq = cp.spawnSync('sh', ['-c', 'command -v jq']).status === 0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[1] scripts are syntactically valid');
+{
+  for (const [name, file] of [['update.sh', UPDATE_SH], ['install.sh', INSTALL_SH], ['warp_egress.sh', WARP_SH]]) {
+    const r = cp.spawnSync('bash', ['-n', file], { encoding: 'utf8' });
+    ok(r.status === 0, 'bash -n ' + name + ' passes (' + (r.stderr || 'clean') + ')');
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[2] update.sh: migrate_config backfills Hy2 fields (never auto-installs)');
+{
+  ok(/migrate_config\(\)/.test(upSrc), 'migrate_config() present');
+  // guard: only migrate when hy2Port OR stack.hy2 is missing
+  ok(/has\("hy2Port"\) and \(\.stack\? \/\/ \{\} \| has\("hy2"\)\)/.test(upSrc),
+     'migrate_config: detects missing hy2Port / stack.hy2 before writing');
+  // the jq expression backfills with defaults but NEVER forces hy2 true
+  ok(/\.hy2Port\s*=\s*\(\.hy2Port \/\/ 443\)/.test(upSrc),
+     'migrate_config: hy2Port defaults to 443 (// keeps a custom value)');
+  ok(/\.stack\.hy2\s*=\s*\(\.stack\.hy2\s*\/\/ false\)/.test(upSrc),
+     'migrate_config: stack.hy2 defaults to FALSE (update never auto-installs Hy2)');
+  ok(/\.stack\.naive\s*=\s*\(\.stack\.naive \/\/ true\)/.test(upSrc)
+     && /\.stack\.mieru\s*=\s*\(\.stack\.mieru \/\/ true\)/.test(upSrc),
+     'migrate_config: stack.naive/mieru default true (they were always installed)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[3] update.sh: migrate_hy2 restarts only when installed, else hints');
+{
+  ok(/migrate_hy2\(\)/.test(upSrc), 'migrate_hy2() present');
+  ok(/-f \/etc\/hysteria\/config\.yaml && -x \/usr\/local\/bin\/hysteria/.test(upSrc),
+     'migrate_hy2: gates on config.yaml + binary (installed detection)');
+  ok(/systemctl restart hysteria-server/.test(upSrc),
+     'migrate_hy2: restarts hysteria-server when installed');
+  ok(/Доустановить Hy2/.test(upSrc),
+     'migrate_hy2: prints the "Доустановить Hy2" hint when NOT installed');
+  ok(/migrate_hy2\b/.test(upSrc.split('do_update')[1] || ''),
+     'do_update calls migrate_hy2');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[4] update.sh: ships install_hysteria.sh executable + repair restarts Hy2');
+{
+  ok(/install_hysteria\.sh warp_egress\.sh cascade_mieru\.sh/.test(upSrc),
+     'update_panel: chmod +x install_hysteria.sh (+ warp/cascade helpers)');
+  ok(/for base in "\$PANEL_DIR\/scripts" "\$PANEL_DIR\/panel\/scripts"/.test(upSrc),
+     'update_panel: chmods BOTH canonical ($PANEL_DIR/scripts) and legacy paths');
+  // do_repair should also restart Hy2 when installed
+  const repair = upSrc.split('do_repair()')[1] || '';
+  ok(/systemctl restart hysteria-server/.test(repair),
+     'do_repair: restarts hysteria-server when Hy2 installed (userpass re-synced from SQLite)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[5] update.sh: do_status surfaces Hy2 state');
+{
+  const status = upSrc.split('do_status()')[1] || '';
+  ok(/hysteria \(Hy2\)/.test(status), 'do_status: shows hysteria (Hy2) version line');
+  ok(/hysteria-server — active \(Hy2\)|hysteria-server — \$hy2s \(Hy2\)/.test(status),
+     'do_status: shows hysteria-server active/inactive when installed');
+  ok(/not installed \(add from Settings/.test(status),
+     'do_status: shows "not installed" hint when Hy2 absent');
+  ok(/hy2Port, stack/.test(status), 'do_status: config dump includes hy2Port + stack');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[6] install.sh: fresh installs ship Hy2 defaults (but do NOT install Hy2)');
+{
+  ok(/hy2Port:\s*num\(E\.CFG_HY2_PORT, 443\)/.test(instSrc),
+     'install.sh: config.json gets hy2Port default 443');
+  ok(/stack:\s*\{ naive: true, mieru: true, hy2: false \}/.test(instSrc),
+     'install.sh: config.json stack defaults (hy2:false — install via panel)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[7] server: runtime backfill + install detection + settings endpoint');
+{
+  ok(/if \(cfg\.hy2Port === undefined \|\| cfg\.hy2Port === null\) cfg\.hy2Port = 443/.test(serverSrc),
+     'server backfills hy2Port on load (belt-and-braces with update.sh)');
+  ok(/if \(cfg\.stack\.hy2\s+=== undefined\) cfg\.stack\.hy2\s+= false/.test(serverSrc),
+     'server backfills stack.hy2=false on load');
+  ok(/function hy2Installed\(\)/.test(serverSrc), 'server has hy2Installed() detection');
+  ok(/app\.get\('\/api\/settings\/hy2'/.test(serverSrc),
+     'server exposes GET /api/settings/hy2 (drives the install card)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[8] Sub-stage D: warp_egress.sh marks the inbound-UDP reply path (Hy2/QUIC)');
+{
+  function fnBody(name) {
+    const re = new RegExp('^' + name + '\\(\\) \\{[\\s\\S]*?\\n\\}', 'm');
+    const m = warpSrc.match(re);
+    return m ? m[0] : '';
+  }
+  const routeUp   = fnBody('route_up');
+  const routeDown = fnBody('route_down');
+  ok(routeUp.length > 0 && routeDown.length > 0, 'route_up()/route_down() located');
+  // set-mark on NEW inbound UDP from a non-WARP iface (mirror of the TCP rule)
+  ok(/-A PREROUTING ! -i "\$dev" -p udp -m conntrack --ctstate NEW -j CONNMARK --set-mark "\$MARK_CONN"/.test(routeUp),
+     'route_up: marks every NEW inbound UDP conn (! -i warp) — Hy2/QUIC reply path');
+  // unconditional OUTPUT restore for UDP so replies carry the mark
+  ok(/-A OUTPUT -p udp -j CONNMARK --restore-mark/.test(routeUp),
+     'route_up: restores the mark on OUTPUT for UDP (QUIC replies carry it)');
+  // idempotent (-C before -A) for the new UDP rule
+  ok(/-C PREROUTING ! -i "\$dev" -p udp -m conntrack --ctstate NEW -j CONNMARK --set-mark "\$MARK_CONN"/.test(routeUp),
+     'route_up: -C check before -A for the UDP inbound-mark rule (idempotent)');
+  // teardown removes the UDP rules symmetrically
+  ok(/-D PREROUTING ! -i "\$dev" -p udp -m conntrack --ctstate NEW -j CONNMARK --set-mark "\$MARK_CONN"/.test(routeDown),
+     'route_down: removes the UDP inbound NEW-connection mark');
+  ok(/-D OUTPUT -p udp -j CONNMARK --restore-mark/.test(routeDown),
+     'route_down: removes the UDP OUTPUT reply-restore');
+  // TCP rules must remain intact (we only ADDED udp, did not remove tcp)
+  ok(/-A PREROUTING ! -i "\$dev" -p tcp -m conntrack --ctstate NEW -j CONNMARK --set-mark "\$MARK_CONN"/.test(routeUp),
+     'route_up: the original BUG-171 TCP rule is still present (Naive/Mieru unaffected)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n[9] LIVE jq migration: legacy config backfilled; users & customs preserved');
+if (!hasJq) {
+  console.log('  \u26a0 skipped (jq not available)');
+} else {
+  const dir = fs.mkdtempSync('/tmp/hy2mig-');
+  try {
+    // The exact jq program used by migrate_config (kept in lock-step).
+    const JQ = '.hy2Port = (.hy2Port // 443)'
+      + ' | .stack = (.stack // {})'
+      + ' | .stack.naive = (.stack.naive // true)'
+      + ' | .stack.mieru = (.stack.mieru // true)'
+      + ' | .stack.hy2 = (.stack.hy2 // false)';
+    const run = (obj) => {
+      const f = path.join(dir, 'c.json');
+      fs.writeFileSync(f, JSON.stringify(obj));
+      const r = cp.spawnSync('jq', [JQ, f], { encoding: 'utf8' });
+      return JSON.parse(r.stdout);
+    };
+
+    // Legacy: has users, no hy2 fields → must gain defaults, users untouched.
+    const legacy = { domain: 'vpn.example.com', naivePort: 8443,
+                     users: [{ username: 'alice', protocols: ['naive', 'mieru'] }] };
+    const a = run(legacy);
+    ok(a.hy2Port === 443, 'legacy → hy2Port backfilled to 443');
+    ok(a.stack && a.stack.naive === true && a.stack.mieru === true && a.stack.hy2 === false,
+       'legacy → stack.{naive,mieru}=true, hy2=false');
+    ok(JSON.stringify(a.users) === JSON.stringify(legacy.users),
+       'legacy → existing users + protocols array left completely untouched');
+    ok(a.naivePort === 8443 && a.domain === 'vpn.example.com',
+       'legacy → all pre-existing fields preserved');
+
+    // Already-migrated with CUSTOM values → idempotent, customs kept.
+    const custom = { hy2Port: 8443, stack: { naive: true, mieru: true, hy2: true } };
+    const b = run(custom);
+    ok(b.hy2Port === 8443, 'migrated → custom hy2Port 8443 preserved (idempotent)');
+    ok(b.stack.hy2 === true, 'migrated → operator-enabled stack.hy2=true preserved');
+
+    // Partial stack → only missing keys filled.
+    const partial = run({ stack: { naive: true } });
+    ok(partial.stack.mieru === true && partial.stack.hy2 === false && partial.hy2Port === 443,
+       'partial stack → missing keys filled, present key kept');
+  } finally {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (e) {}
+  }
+}
+
+console.log('\nResult: ' + pass + ' passed, ' + fail + ' failed');
+process.exit(fail ? 1 : 0);

--- a/update.sh
+++ b/update.sh
@@ -401,6 +401,31 @@ migrate_config() {
     rm -f "$tmp2"
   fi
 
+  # v1.8.0 (Hy2 Sub-stage C): backfill the Hysteria2 config fields for installs
+  # that predate the 3rd protocol. We add hy2Port (default 443/udp) and the
+  # stack.{naive,mieru,hy2} map. CRITICAL: stack.hy2 defaults to FALSE — the
+  # update NEVER auto-installs Hy2; it only makes the "Доустановить Hy2" button
+  # available in Settings (the server reports installed:false via
+  # /api/settings/hy2, so the UI renders the install card). Existing users and
+  # their protocols array are left completely untouched. This mirrors the
+  # server-side runtime backfill (index.js) so the config is correct even before
+  # the panel process restarts.
+  local has_hy2; has_hy2=$(jq -r 'has("hy2Port") and (.stack? // {} | has("hy2"))' "$PANEL_CONFIG" 2>/dev/null)
+  if [[ "$has_hy2" != "true" ]]; then
+    local tmp3; tmp3=$(mktemp)
+    if jq '
+        .hy2Port      = (.hy2Port // 443)
+      | .stack        = (.stack // {})
+      | .stack.naive  = (.stack.naive // true)
+      | .stack.mieru  = (.stack.mieru // true)
+      | .stack.hy2    = (.stack.hy2   // false)
+    ' "$PANEL_CONFIG" > "$tmp3" 2>/dev/null && [[ -s "$tmp3" ]]; then
+      cat "$tmp3" > "$PANEL_CONFIG"
+      log_info "Config migrated: Hy2 fields added (hy2Port=443/udp, stack.hy2=false — install via Settings) ✓"
+    fi
+    rm -f "$tmp3"
+  fi
+
   # BUG-155 (HIGH): self-heal a polluted panelBasicAuthHash. A pre-fix installer
   # could capture `apt-get install apache2-utils` stdout (Selecting previously…,
   # Unpacking…, needrestart banner) into the hash → multi-line value → invalid
@@ -1078,6 +1103,30 @@ migrate_cascade_watchdog() {
   fi
 }
 
+# ── v1.8.0 (Hy2 Sub-stage C): Hysteria2 update migration ─────────────────────
+#   Hy2 is the OPTIONAL third protocol. This migration NEVER auto-installs it.
+#     • Installed (config + binary present): restart hysteria-server so the
+#       refreshed unit/config (and any panel-rewritten userpass) take effect,
+#       exactly like caddy-naive/mita above. The panel keeps the userpass map in
+#       sync from the SQLite pool on the next applyAllConfigs(), so existing Hy2
+#       users are NOT dropped.
+#     • Not installed: print a one-line hint that Hy2 can be added from Settings
+#       ("Доустановить Hy2"). No side effects — existing installs are untouched.
+#   Idempotent and safe under -y / --dry-run.
+migrate_hy2() {
+  $DRY_RUN && { log_dry "Would restart hysteria-server if Hy2 is installed (else print an install hint)"; return 0; }
+  if [[ -f /etc/hysteria/config.yaml && -x /usr/local/bin/hysteria ]]; then
+    systemctl reset-failed hysteria-server 2>/dev/null || true
+    if systemctl restart hysteria-server 2>/dev/null; then
+      log_info "Hy2: hysteria-server restarted to pick up the update ✓"
+    else
+      log_warn "Hy2: hysteria-server restart failed — journalctl -u hysteria-server -n 20"
+    fi
+  else
+    log_info "Hy2 (Hysteria2) is available but NOT installed — add it any time from the panel: Settings → «Доустановить Hy2» (443/udp by default, reuses the Caddy cert)."
+  fi
+}
+
 # ── Bug 79: fix caddy-naive config permissions ───────────────────────────────
 #   caddy-naive runs as User=caddy and fails to start with
 #     "reading config from file: open /etc/caddy-naive/Caddyfile: permission denied"
@@ -1280,6 +1329,20 @@ update_panel() {
   done
   chmod +x "$PANEL_DIR/update.sh" "$PANEL_DIR/install.sh" "$PANEL_DIR/uninstall.sh" 2>/dev/null || true
 
+  # v1.8.0 (Hy2 Sub-stage C): make the shipped helper scripts executable so the
+  # panel can run them. install_hysteria.sh is the Hy2 installer invoked by
+  # POST /api/settings/hy2/install (the "Доустановить Hy2" button); warp_egress.sh
+  # / cascade_mieru.sh are the WARP + cascade helpers. `cp -a` preserves mode from
+  # the repo, but a git/tarball checkout may land them non-executable — force it.
+  # NOTE: server/index.js resolves scripts via __dirname/../scripts, so on prod
+  # they live at $PANEL_DIR/scripts. We chmod BOTH that canonical location and the
+  # legacy $PANEL_DIR/panel/scripts path (older layouts) to be safe.
+  for base in "$PANEL_DIR/scripts" "$PANEL_DIR/panel/scripts"; do
+    for s in install_hysteria.sh warp_egress.sh cascade_mieru.sh; do
+      [[ -f "$base/$s" ]] && chmod +x "$base/$s" 2>/dev/null || true
+    done
+  done
+
   # npm install must NOT be fatal — keep going even on a transient failure.
   ( cd "$PANEL_DIR" && npm install --omit=dev --silent ) \
     || ( cd "$PANEL_DIR" && npm install --production --silent ) \
@@ -1319,6 +1382,17 @@ smoke_test() {
   # v1.2.3: check caddy-naive (not legacy naive)
   check_svc caddy-naive
   check_svc mita
+
+  # v1.8.0 (Hy2 Sub-stage C): Hy2 is OPTIONAL — only smoke-test it when the
+  # operator has actually installed it (config + binary present). A box that
+  # never enabled Hy2 must NOT be flagged as failing.
+  if [[ -f /etc/hysteria/config.yaml && -x /usr/local/bin/hysteria ]]; then
+    if systemctl is-active --quiet hysteria-server; then
+      echo -e "  ${GREEN}✓${NC} hysteria-server active (Hy2)"; (( pass++ ))
+    else
+      echo -e "  ${YELLOW}⚠${NC}  hysteria-server INACTIVE (Hy2 installed) — journalctl -u hysteria-server -n 20"
+    fi
+  fi
 
   # caddy-naive version check
   if timeout 5 "$CADDY_BIN" version &>/dev/null 2>&1 || \
@@ -1387,6 +1461,7 @@ do_status() {
   echo "  Panel:          $(get_current_version) (target: $TARGET_VERSION)"
   echo "  caddy-naive:    $("$CADDY_BIN" version 2>/dev/null | head -1 || echo 'not installed')"
   echo "  mita:           $(mita version 2>/dev/null | head -1 || echo 'not installed')"
+  echo "  hysteria (Hy2): $([[ -x /usr/local/bin/hysteria ]] && /usr/local/bin/hysteria version 2>/dev/null | head -1 || echo 'not installed')"
   echo "  Node.js:        $(node --version 2>/dev/null || echo 'not installed')"
   echo "  PM2:            $(pm2 --version 2>/dev/null || echo 'not installed')"
   echo ""
@@ -1408,6 +1483,18 @@ do_status() {
       echo -e "  ${RED}●${NC} $svc — $status"
     fi
   done
+  # v1.8.0: Hy2 (Hysteria2) — only shown when the optional 3rd protocol is
+  # installed; a box that never enabled it simply omits the line.
+  if [[ -f /etc/hysteria/config.yaml && -x /usr/local/bin/hysteria ]]; then
+    local hy2s; hy2s=$(systemctl is-active hysteria-server 2>/dev/null || echo "unknown")
+    if [[ "$hy2s" == "active" ]]; then
+      echo -e "  ${GREEN}●${NC} hysteria-server — active (Hy2)"
+    else
+      echo -e "  ${RED}●${NC} hysteria-server — $hy2s (Hy2)"
+    fi
+  else
+    echo -e "  ${YELLOW}○${NC} hysteria-server — not installed (add from Settings → «Доустановить Hy2»)"
+  fi
   # Legacy naive check
   if systemctl is-active naive &>/dev/null 2>&1; then
     echo -e "  ${YELLOW}●${NC} naive — active (LEGACY — should have been removed in v1.2.3 migration)"
@@ -1421,6 +1508,7 @@ do_status() {
   echo -e "${BOLD}Configuration:${NC}"
   if [[ -f "$PANEL_CONFIG" ]]; then
     jq '{ domain, serverIp, naivePort, mieruPortStart, mieruPortEnd,
+          hy2Port, stack,
           exposePanel, trafficPattern, mtu, udpEnabled,
           fakeSiteUrl, probeSecret }' \
       "$PANEL_CONFIG" 2>/dev/null | sed 's/^/  /'
@@ -1740,6 +1828,16 @@ FAKEHTML
   systemctl restart mita 2>/dev/null && log_info "mita restarted ✓" || \
     log_warn "mita restart failed — journalctl -u mita -n 20"
 
+  # v1.8.0 (Hy2 Sub-stage C): if Hy2 is installed, restart it too. The panel
+  # rewrites /etc/hysteria/config.yaml's userpass map from the SQLite pool on its
+  # next applyAllConfigs(), so a repair keeps Hy2 users in sync (no data loss).
+  # Skipped entirely when Hy2 was never installed.
+  if [[ -f /etc/hysteria/config.yaml && -x /usr/local/bin/hysteria ]]; then
+    systemctl reset-failed hysteria-server 2>/dev/null || true
+    systemctl restart hysteria-server 2>/dev/null && log_info "hysteria-server restarted (Hy2) ✓" || \
+      log_warn "hysteria-server restart failed — journalctl -u hysteria-server -n 20"
+  fi
+
   # Bug 104 (v1.4.2): --repair previously left config.json's "version" untouched,
   # so PM2 / the UI kept reporting a stale version (e.g. 1.2.6 while 1.4.x is
   # installed). Sync config.json to the installed VERSION *before* restarting the
@@ -1858,6 +1956,10 @@ do_update() {
   # BUG-172 migration: refresh the cascade watchdog (full-chain probe + nightly
   # redsocks recycle) on any box that currently has the Mieru cascade enabled.
   migrate_cascade_watchdog
+
+  # v1.8.0 (Hy2 Sub-stage C): restart Hy2 if installed, else hint how to add it.
+  # Runs BEFORE the dry-run gate returns so --dry-run reports the intended action.
+  migrate_hy2
 
   $DRY_RUN && { log_info "[DRY-RUN] No changes were made."; return; }
 


### PR DESCRIPTION
## Summary
Completes **Sub-stage C** of the Hy2 integration (after PR #68 backend + PR #69 UI/WARP, both merged). Existing Naive+Mieru installs now upgrade to the Hy2 build **cleanly and with zero data loss** — the «Доустановить Hy2» button appears automatically after a plain `update.sh`.

### `update.sh`
- **`migrate_config`**: backfills `hy2Port` (443/udp) + `stack.{naive,mieru,hy2}` into config.json for pre-Hy2 installs. **`stack.hy2` defaults to `false` — update NEVER auto-installs Hy2**, it only enables the install card. Idempotent (jq `//` fallbacks keep custom `hy2Port` / operator-enabled `stack.hy2=true`). **Existing `users` + `protocols` arrays untouched.**
- **`migrate_hy2`**: restart `hysteria-server` **only if installed**; else print a «Доустановить Hy2» hint. Wired into `do_update`.
- **`do_repair`**: also restarts Hy2 when installed (panel re-syncs userpass from SQLite → no user loss).
- **`update_panel`**: `chmod +x` install_hysteria.sh / warp_egress.sh / cascade_mieru.sh (both `$PANEL_DIR/scripts` and legacy layouts).
- **`smoke_test` + `do_status`**: Hy2 version line, active/inactive/not-installed indicator, hy2Port+stack in config dump. All Hy2 checks warn-only / gated on install → a box without Hy2 is never flagged failing.

### `install.sh`
- Fresh installs write `hy2Port:443` + `stack{naive:true,mieru:true,hy2:false}` (Hy2 added later from the panel).

### Tests
- **`tests/feat-hy2-migration.test.js`** — 40 assertions, wired into `npm test`: config backfill + idempotency + **users/customs preserved (live jq)**, migrate_hy2 restart-only-when-installed, update_panel chmod, do_repair Hy2 restart, do_status wiring, install.sh defaults, server runtime backfill + `/api/settings/hy2`, Sub-stage D WARP UDP rules present + BUG-171 TCP rule intact.

### Validation
- `bash -n update.sh/install.sh/warp_egress.sh` OK; package.json valid
- **Full suite: 18 files, all green, 0 failed**
- jq migration proven on legacy / partial / already-migrated configs — custom values preserved, users never touched
- User CRUD (create/edit/delete) verified intact — 8 `applyAllConfigs()` call sites, `writeHysteriaConfig()` no-ops safely when Hy2 not installed, `VALID_PROTOCOLS` guard present

### Hy2 integration status
- [x] Sub-stage A — installer + config model (PR #68)
- [x] Sub-stage B-API — endpoints + status/diagnostics (PR #68)
- [x] Sub-stage B-UI — full frontend (PR #69)
- [x] Sub-stage D — WARP UDP compatibility (PR #69)
- [x] **Sub-stage C — upgrade migration (this PR)** ✅ Hy2 integration complete